### PR TITLE
Support install custom plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,7 +133,7 @@ function installPlugins() {
 
     // validate
     plugins.forEach( function(plugin) {
-      if (!/^[a-zA-Z0-9-]+$/.test(plugin)) {
+      if (!/^\w\S+$/.test(plugin)) {
         throw `Invalid plugin: ${plugin}`;
       }
     });
@@ -147,10 +147,10 @@ function installPlugins() {
       pluginCmd += '.bat';
     }
     if (atOnce) {
-      run(pluginCmd, 'install', '--silent', ...plugins);
+      run(pluginCmd, 'install', '--silent', '--batch', ...plugins);
     } else {
       plugins.forEach( function(plugin) {
-        run(pluginCmd, 'install', '--silent', plugin);
+        run(pluginCmd, 'install', '--silent', '--batch', plugin);
       });
     }
   }


### PR DESCRIPTION
### Reason

Look [here](https://www.elastic.co/guide/en/elasticsearch/plugins/current/plugin-management-custom-url.html#plugin-management-custom-url), elasticsearch allow install custom plugin from url or file system，but it can't do it due to plugin validate

### Changed

- Update plugin regex validate for match url or path
- Command elasticsearch-plugin use `--batch` options for automatic confirmation operation

_PS: English is not my native language; please excuse typing errors._